### PR TITLE
Make blackholehunter work in standalone mode again

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ gravitational waves through sound, developed by
 
 1. Install [Python](https://www.python.org/).
 2. Install [Node.js](https://nodejs.org). We used the 18.13.0 release, which provides ` npm --version` of 8.6.0. It's possible that issues will exist in other versions, but hopefully this won't be too sensitive to version number.
-3. `git clone https://gravity.astro.cf.ac.uk/git/black-hole-hunter/`
+3. `git clone https://github.com/cardiffgravity/black-hole-hunter.git`
 4. Run `npm install .` in the root directory of the cloned website.
 5. Install `webpack` globally with `npm install -g webpack` and `npm install -g webpack-cli`
 

--- a/README.md
+++ b/README.md
@@ -7,15 +7,15 @@ gravitational waves through sound, developed by
 ## Installation
 
 1. Install [Python](https://www.python.org/).
-2. Install [Node.js](https://nodejs.org).
+2. Install [Node.js](https://nodejs.org). We used the 18.13.0 release, which provides ` npm --version` of 8.6.0. It's possible that issues will exist in other versions, but hopefully this won't be too sensitive to version number.
 3. `git clone https://gravity.astro.cf.ac.uk/git/black-hole-hunter/`
 4. Run `npm install .` in the root directory of the cloned website.
-5. Install `webpack` globally with `npm install -g webpack`.
+5. Install `webpack` globally with `npm install -g webpack` and `npm install -g webpack-cli`
 
 ## Usage
 
 1. Run `webpack` in the root directory of the cloned website.
-1. Run `python -m SimpleHTTPServer` in the root directory of the cloned website.
+1. Run `python -m http.server 8000` in the root directory of the cloned website.
 2. Open a browser at `http://localhost:8000`.
 
 ## Acknowledgements

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Galadirith/black-hole-hunter.git"
+    "url": "git+https://github.com/cardiffgravity/black-hole-hunter.git"
   },
   "keywords": [
     "gravitational",
@@ -21,22 +21,15 @@
     "outreach"
   ],
   "bugs": {
-    "url": "https://github.com/Galadirith/black-hole-hunter/issues"
+    "url": "https://github.com/cardiffgravity/black-hole-hunter/issues"
   },
-  "homepage": "https://github.com/Galadirith/black-hole-hunter",
+  "homepage": "https://github.com/cardiffgravity/black-hole-hunter",
   "devDependencies": {
-    "coffee-loader": "^0.7.2",
-    "coffee-script": "^1.12.3",
-    "css-loader": "^0.26.1",
-    "extract-loader": "^0.1.0",
-    "file-loader": "^0.9.0",
-    "json-loader": "^0.5.4",
-    "node-sass": "^4.3.0",
-    "null-loader": "^0.1.1",
-    "raw-loader": "^0.5.1",
-    "sass-loader": "^4.1.1",
-    "style-loader": "^0.13.1",
-    "webpack": "^1.15.0",
-    "webpack-dev-server": "^1.16.2"
+    "coffee-loader": "4.0.0",
+    "file-loader": "6.2.0",
+    "raw-loader": "4.0.2",
+    "style-loader": "3.3.1",
+    "webpack": "5.75.0",
+    "webpack-dev-server": "4.11.1"
   }
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,7 +1,6 @@
 var webpack = require('webpack');
 
 module.exports = {
-    debug: true,
     entry: {
         splash: './coffee/splash.coffee',
         game: './coffee/game.coffee',
@@ -13,18 +12,10 @@ module.exports = {
         filename: './js/[name].js'
     },
     module: {
-        loaders: [{
-          test: /\.coffee$/,
-          loader: "coffee"
-        },{
-          test: /\.scss$/,
-          loader: "file-loader?name=css/[name].css!extract!css!sass"
-        },{
-          test: /\.html$/,
-          loader: "raw"
-        },{
-          test: /\.json$/,
-          loader: "json"
-        }]
+        rules: [
+          {test: /\.coffee$/, use: "coffee-loader"},
+          {test: /\.scss$/, use: "file-loader?name=css/[name].css!extract!css!sass"},
+          {test: /\.html$/, use: "raw-loader"},
+        ]
     }
 };


### PR DESCRIPTION
The instructions to install blackholehunter in offline mode basically don't work; for a variety of reasons:

* The package versions are very old and require python2, which is increasingly hard to get nowadays.
* The package versions are very old and (at least parts of them/dependencies) don't seem to compile on many modern compilers.
* SimpleHTTPServer is a python2 thing as well.
* The webpack version to be installed globally was never specified, and the current version requires webpack-cli to be installed alongside it.

Updating the package versions, and moving to python3 requires some fiddling of the config files. A number of the dependencies are also provided in the core Node.js package and don't seem to need specifying (e.g. there is a StackOverflow article on why we don't need to specify the json-loader any more). 

While I was tweaking I also updated a few URLs to point here. Would be good to have someone check this all. I'm not sure who the maintainer is on the Cardiff side.